### PR TITLE
(exchange-api) add getPrice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -163,7 +163,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
       "requires": {
         "kind-of": "3.2.2",
         "longest": "1.0.1",
@@ -173,8 +172,7 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-escapes": {
       "version": "3.0.0",
@@ -1214,7 +1212,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "dev": true,
       "optional": true
     },
     "caniuse-lite": {
@@ -1233,7 +1230,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
       "optional": true,
       "requires": {
         "align-text": "0.1.4",
@@ -1319,7 +1315,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
       "optional": true,
       "requires": {
         "center-align": "0.1.3",
@@ -1331,7 +1326,6 @@
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true,
           "optional": true
         }
       }
@@ -1492,8 +1486,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "deep-eql": {
       "version": "0.1.3",
@@ -2027,6 +2020,14 @@
       "dev": true,
       "requires": {
         "bser": "2.0.0"
+      }
+    },
+    "fetch-this": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-this/-/fetch-this-0.2.0.tgz",
+      "integrity": "sha512-vWZlM6DhKnmJVWtT/oNdPL+AxARJp4K5XPW5rJGUTeqIaISZIobSI9FHg4rwMjAfbqMvbX1BqI4qzeWVQEQZUA==",
+      "requires": {
+        "handlebars": "4.0.11"
       }
     },
     "figures": {
@@ -3161,7 +3162,6 @@
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
-      "dev": true,
       "requires": {
         "async": "1.5.2",
         "optimist": "0.6.1",
@@ -3172,14 +3172,12 @@
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
           "requires": {
             "amdefine": "1.0.1"
           }
@@ -3396,8 +3394,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -4170,7 +4167,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
       "requires": {
         "is-buffer": "1.1.6"
       }
@@ -4179,7 +4175,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true,
       "optional": true
     },
     "lcid": {
@@ -4255,6 +4250,11 @@
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -4264,8 +4264,7 @@
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -4373,8 +4372,7 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -4568,7 +4566,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8",
         "wordwrap": "0.0.3"
@@ -4577,8 +4574,7 @@
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
         }
       }
     },
@@ -5040,8 +5036,7 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "2.0.1",
@@ -5170,7 +5165,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
       "optional": true,
       "requires": {
         "align-text": "0.1.4"
@@ -5311,8 +5305,7 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-support": {
       "version": "0.5.2",
@@ -5663,7 +5656,6 @@
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "dev": true,
       "optional": true,
       "requires": {
         "source-map": "0.5.7",
@@ -5675,7 +5667,6 @@
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
           "optional": true,
           "requires": {
             "camelcase": "1.2.1",
@@ -5690,7 +5681,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
       "optional": true
     },
     "util-deprecate": {
@@ -5808,7 +5798,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true,
       "optional": true
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "fix": "fixpack && eslint . --fix --ignore-pattern !/.*rc.js",
     "test": "jest --watch"
   },
-  "dependencies": {},
+  "dependencies": {
+    "fetch-this": "^0.2.0",
+    "handlebars": "^4.0.11",
+    "lodash.get": "^4.4.2"
+  },
   "devDependencies": {
     "babel-eslint": "^8.2.1",
     "babel-preset-env": "^1.6.1",

--- a/src/exchange-api/sdk.js
+++ b/src/exchange-api/sdk.js
@@ -1,0 +1,12 @@
+import fetchThis from 'fetch-this'
+import Handlebars from 'handlebars'
+import get from 'lodash.get'
+
+export const getPrice = async (exchange, payload) => {
+  const response = await fetchThis(exchange.api.fetch, payload)
+  const body = await response.json()
+
+  const resultPath = Handlebars.compile(exchange.api.result)(payload)
+
+  return get(body, resultPath)
+}

--- a/src/exchange-api/sdk.test.js
+++ b/src/exchange-api/sdk.test.js
@@ -3,27 +3,41 @@ describe.skip('get price from exchange', () => {
   test('currency details on url path', async () => {
     const exchange = {
       name: 'FakeExchange',
-      connect: {
-        url: 'https://FakeExchange.com/ticker/{options.currency_from}{options.currency_to}/',
-        result: 'response.last',
+      api: {
+        fetch: {
+          url: 'https://FakeExchange.com/ticker/{{ currency_from }}_{{ currency_to }}/',
+        },
+        result: 'last',
       },
     }
+
+    const options = {
+      currency_from: 'ltc',
+      currency_to: 'usd',
+    }
+
     const price = await getPrice(exchange, options)
+
     expect(price).toBe(185.00)
   })
-  test('request without currency details', async () => {
+
+  test('currency details mixed on response', async () => {
     const exchange = {
       name: 'FakeExchange',
-      connect: {
-        url: 'https://FakeExchange.com/ticker/',
-        result: 'response[{options.currency_from}_{options.currency_to}].last_trade',
+      api: {
+        fetch: {
+          url: 'https://FakeExchange.com/ticker/',
+        },
+        result: '{{ currency_from }}_{{ currency_to }}.last_trade',
       },
     }
+
     const options = {
-      currency_from: 'LTC',
-      currency_to: 'USD',
+      currency_from: 'ltc',
+      currency_to: 'usd',
     }
     const price = await getPrice(exchange, options)
+
     expect(price).toBe(185.00)
   })
 })

--- a/src/exchange-api/sdk.test.js
+++ b/src/exchange-api/sdk.test.js
@@ -1,0 +1,29 @@
+
+describe.skip('get price from exchange', () => {
+  test('currency details on url path', async () => {
+    const exchange = {
+      name: 'FakeExchange',
+      connect: {
+        url: 'https://FakeExchange.com/ticker/{options.currency_from}{options.currency_to}/',
+        result: 'response.last',
+      },
+    }
+    const price = await getPrice(exchange, options)
+    expect(price).toBe(185.00)
+  })
+  test('request without currency details', async () => {
+    const exchange = {
+      name: 'FakeExchange',
+      connect: {
+        url: 'https://FakeExchange.com/ticker/',
+        result: 'response[{options.currency_from}_{options.currency_to}].last_trade',
+      },
+    }
+    const options = {
+      currency_from: 'LTC',
+      currency_to: 'USD',
+    }
+    const price = await getPrice(exchange, options)
+    expect(price).toBe(185.00)
+  })
+})

--- a/src/exchange-api/sdk.test.js
+++ b/src/exchange-api/sdk.test.js
@@ -1,5 +1,7 @@
+import { getPrice } from './sdk'
+import nock from 'nock'
 
-describe.skip('get price from exchange', () => {
+describe('get price from exchange', () => {
   test('currency details on url path', async () => {
     const exchange = {
       name: 'FakeExchange',
@@ -11,12 +13,16 @@ describe.skip('get price from exchange', () => {
       },
     }
 
-    const options = {
+    const payload = {
       currency_from: 'ltc',
       currency_to: 'usd',
     }
 
-    const price = await getPrice(exchange, options)
+    nock('https://FakeExchange.com')
+      .get('/ticker/ltc_usd/')
+      .reply(200, { last: 185.00 })
+
+    const price = await getPrice(exchange, payload)
 
     expect(price).toBe(185.00)
   })
@@ -32,11 +38,16 @@ describe.skip('get price from exchange', () => {
       },
     }
 
-    const options = {
+    const payload = {
       currency_from: 'ltc',
       currency_to: 'usd',
     }
-    const price = await getPrice(exchange, options)
+
+    nock('https://FakeExchange.com')
+      .get('/ticker/')
+      .reply(200, { ltc_usd: { last_trade: 185.00 } })
+
+    const price = await getPrice(exchange, payload)
 
     expect(price).toBe(185.00)
   })


### PR DESCRIPTION
This PR creates the exchange-api module, responsible for communicating with exchanges.
It also adds the `getPrice` method, to fetch exchange data from an api.

`getPrice` accepts two parameters for now:
1) exchange
It's a exchange data, with it's name and api connection data.
Something like:
```
    {
      "name": "FakeExchange",
      "api": {
        "fetch": {
          "url": "https://fake.exchange.com"
        }
      "result": "path.to.value"
      }
    },
```
Both url and result properties can be Handlebars templates

2) payload
This `payload` will be provided to Handlebars templates